### PR TITLE
Delete `package.meta`

### DIFF
--- a/package.meta
+++ b/package.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: dcd565726e0adc342ad8407096c79e77
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
This PR deletes the stray `package.meta` file that was included in the published UPM package.

Since no `package` file or folder exists, Unity reports warnings on every domain reload and cannot remove the `.meta` file due to the package cache being read‑only.

Fixes #18.